### PR TITLE
:recycle:refactor: substituir interfaces por types e centralizar definições em /types

### DIFF
--- a/src/components/confirmModal/index.tsx
+++ b/src/components/confirmModal/index.tsx
@@ -1,15 +1,5 @@
 import React from 'react';
-
-interface ConfirmModalProps {
-  isOpen: boolean;
-  onClose: () => void;
-  onConfirm: () => void;
-  title: string;
-  description: string;
-  confirmText?: string;
-  cancelText?: string;
-  variant?: 'danger' | 'success';
-}
+import { ConfirmModalProps } from "@/types/type";
 
 export const ConfirmModal: React.FC<ConfirmModalProps> = ({
   isOpen,

--- a/src/components/formComponents/index.tsx
+++ b/src/components/formComponents/index.tsx
@@ -1,5 +1,8 @@
 import React from "react";
 
+interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  label: string;
+}
 export const FormField = ({
   label,
   children,
@@ -15,9 +18,6 @@ export const FormField = ({
   </div>
 );
 
-interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
-  label: string;
-}
 
 export const FormInput = ({ label, ...props }: InputProps) => (
   <FormField label={label}>

--- a/src/components/userTypeCard/index.tsx
+++ b/src/components/userTypeCard/index.tsx
@@ -1,12 +1,5 @@
 import React from 'react';
-
-interface UserTypeCardProps {
-  type: 'student' | 'teacher';
-  title: string;
-  iconSrc: string;
-  iconAlt: string;
-  onClick?: () => void;
-}
+import { UserTypeCardProps } from "@/types/type";
 
 export const UserTypeCard: React.FC<UserTypeCardProps> = ({
   type,

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,19 +1,7 @@
 import React, { createContext, useContext, useState, ReactNode, useEffect } from 'react';
-import { validateProfessorLogin, Professor } from '@/data/mockUsers';
+import { validateProfessorLogin } from '@/data/mockUsers';
 
-interface User {
-  id: string;
-  email: string;
-  name: string;
-  type: 'professor' | 'student';
-}
-
-interface AuthContextType {
-  user: User | null;
-  login: (email: string, password: string) => Promise<{ success: boolean; error?: string }>;
-  logout: () => void;
-  isAuthenticated: boolean;
-}
+import { AuthContextType, User } from "@/types/type";
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 

--- a/src/contexts/QuizContext.tsx
+++ b/src/contexts/QuizContext.tsx
@@ -1,49 +1,6 @@
 import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
 import { toast } from 'sonner';
-
-export interface QuizQuestion {
-  id: string;
-  enunciado: string;
-  alternativas: {
-    texto: string;
-    correta: boolean;
-  }[];
-  tipo: 'texto' | 'imagem' | 'video' | 'mista';
-}
-
-export interface QuizConfig {
-  nivel: string;
-  categorias: {
-    texto: boolean;
-    imagem: boolean;
-    video: boolean;
-    misturado: boolean;
-  };
-  tempoPorQuestao: number;
-  quantidadeQuestoes: number;
-  titulo?: string;
-}
-
-export interface Quiz {
-  id: string;
-  config: QuizConfig;
-  questoes: QuizQuestion[];
-  criadoEm: Date;
-}
-
-interface QuizContextType {
-  currentQuiz: Quiz | null;
-  savedQuizzes: Quiz[];
-  setConfig: (config: QuizConfig) => void;
-  addQuestion: (question: QuizQuestion) => void;
-  updateQuestion: (id: string, question: QuizQuestion) => void;
-  deleteQuestion: (id: string) => void;
-  reorderQuestions: (fromIndex: number, toIndex: number) => void;
-  saveQuiz: () => void;
-  deleteQuiz: (id: string) => void;
-  resetCurrentQuiz: () => void;
-  loadQuizzes: () => void;
-}
+import { QuizConfig,QuizQuestion,Quiz,QuizContextType } from "@/types/type";
 
 const QuizContext = createContext<QuizContextType | undefined>(undefined);
 

--- a/src/contexts/RoomContext.tsx
+++ b/src/contexts/RoomContext.tsx
@@ -1,32 +1,5 @@
 import React, { createContext, useContext, useState, ReactNode } from 'react';
-import { Quiz } from './QuizContext';
-
-export interface Student {
-  id: string;
-  name: string;
-  joinedAt: Date;
-}
-
-export interface Room {
-  id: string;
-  code: string;
-  quiz: Quiz;
-  students: Student[];
-  status: 'waiting' | 'playing' | 'finished';
-  createdAt: Date;
-  startedAt?: Date;
-}
-
-interface RoomContextType {
-  currentRoom: Room | null;
-  createRoom: (quiz: Quiz) => string;
-  addStudent: (studentName: string) => void;
-  removeStudent: (studentId: string) => void;
-  startQuiz: () => void;
-  endQuiz: () => void;
-  getRoomByCode: (code: string) => Room | null;
-  closeRoom: () => void;
-}
+import { Quiz,Student,Room,RoomContextType } from "@/types/type";
 
 const RoomContext = createContext<RoomContextType | undefined>(undefined);
 

--- a/src/data/mockUsers.ts
+++ b/src/data/mockUsers.ts
@@ -1,10 +1,4 @@
-// Interface de professor
-export interface Professor {
-  id: string;
-  name: string;
-  email: string;
-  type: 'professor';
-}
+import { Professor } from "@/types/type";
 
 const API_URL = 'http://localhost:3001/api';
 

--- a/src/pages/professor/CreateQuiz/Step2.tsx
+++ b/src/pages/professor/CreateQuiz/Step2.tsx
@@ -1,10 +1,13 @@
 import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { ChevronUp, ChevronDown, X } from "lucide-react";
-import { useQuiz, QuizQuestion } from "@/contexts/QuizContext";
+import { useQuiz } from "@/contexts/QuizContext";
 import { toast } from "@/hooks/use-toast";
 import { Layout } from "@/components/layout";
 import { FormField } from "@/components/formComponents";
+import { QuizQuestion} from "@/types/type";
+
+
 
 export const CreateQuizStep2: React.FC = () => {
   const navigate = useNavigate();

--- a/src/pages/professor/QuizRoom.tsx
+++ b/src/pages/professor/QuizRoom.tsx
@@ -7,12 +7,8 @@ import { ConfirmModal } from "@/components/confirmModal";
 import { useQuiz } from "@/contexts/QuizContext";
 import { socketService } from "@/services/socketService";
 import { toast } from "sonner";
+import { Student } from "@/types/type";
 
-interface Student {
-  id: string;
-  name: string;
-  joinedAt: Date;
-}
 
 export const QuizRoomPage: React.FC = () => {
   const navigate = useNavigate();

--- a/src/pages/student/QuizPlay.tsx
+++ b/src/pages/student/QuizPlay.tsx
@@ -4,11 +4,8 @@ import { Timer, CheckCircle } from "lucide-react";
 import { Layout } from "@/components/layout";
 import { socketService } from "@/services/socketService";
 import { toast } from "@/hooks/use-toast";
+import { QuestionData } from "@/types/type";
 
-interface QuestionData {
-  enunciado: string;
-  alternativas: { texto: string }[];
-}
 
 export const StudentQuizPage: React.FC = () => {
   const navigate = useNavigate();

--- a/src/pages/student/Results.tsx
+++ b/src/pages/student/Results.tsx
@@ -2,13 +2,7 @@ import React, { useEffect, useState } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 import { Trophy, Medal, Award, Home } from "lucide-react";
 import { Layout } from "@/components/layout";
-
-interface Result {
-  id: string;
-  name: string;
-  score: number;
-  totalQuestions: number;
-}
+import { Result } from "@/types/type";
 
 export const StudentResultsPage: React.FC = () => {
   const navigate = useNavigate();

--- a/src/pages/student/WaitingRoom.tsx
+++ b/src/pages/student/WaitingRoom.tsx
@@ -5,23 +5,8 @@ import { ConfirmModal } from "@/components/confirmModal";
 import { socketService } from "@/services/socketService";
 import { toast } from "sonner";
 import { Layout } from "@/components/layout";
+import { Quiz,Student } from "@/types/type";
 
-interface QuizConfig {
-  nivel: string;
-  tempoPorQuestao: number;
-  titulo: string;
-}
-
-interface Quiz {
-  config: QuizConfig;
-  questoes: any[];
-}
-
-interface Student {
-  id: string;
-  name: string;
-  joinedAt: Date;
-}
 
 export const StudentWaitingRoom: React.FC = () => {
   const navigate = useNavigate();

--- a/src/types/type.ts
+++ b/src/types/type.ts
@@ -1,0 +1,125 @@
+export type User = {
+  id: string;
+  email: string;
+  name: string;
+  type: 'professor' | 'student';
+};
+
+export type AuthContextType = {
+  user: User | null;
+  login: (email: string, password: string) => Promise<{ success: boolean; error?: string }>;
+  logout: () => void;
+  isAuthenticated: boolean;
+};
+
+
+export type QuizQuestion = {
+  id: string;
+  enunciado: string;
+  alternativas: {
+    texto: string;
+    correta: boolean;
+  }[];
+  tipo: 'texto' | 'imagem' | 'video' | 'mista';
+};
+
+export type QuizConfig = {
+  nivel: string;
+  categorias: {
+    texto: boolean;
+    imagem: boolean;
+    video: boolean;
+    misturado: boolean;
+  };
+  tempoPorQuestao: number;
+  quantidadeQuestoes: number;
+  titulo?: string;
+};
+
+export type Quiz = {
+  id: string;
+  config: QuizConfig;
+  questoes: QuizQuestion[];
+  criadoEm: Date;
+};
+
+export type QuizContextType = {
+  currentQuiz: Quiz | null;
+  savedQuizzes: Quiz[];
+  setConfig: (config: QuizConfig) => void;
+  addQuestion: (question: QuizQuestion) => void;
+  updateQuestion: (id: string, question: QuizQuestion) => void;
+  deleteQuestion: (id: string) => void;
+  reorderQuestions: (fromIndex: number, toIndex: number) => void;
+  saveQuiz: () => void;
+  deleteQuiz: (id: string) => void;
+  resetCurrentQuiz: () => void;
+  loadQuizzes: () => void;
+};
+
+export type Student = {
+  id: string;
+  name: string;
+  joinedAt: Date;
+};
+
+
+export type Room = {
+  id: string;
+  code: string;
+  quiz: Quiz;
+  students: Student[];
+  status: 'waiting' | 'playing' | 'finished';
+  createdAt: Date;
+  startedAt?: Date;
+};
+
+export type RoomContextType = {
+  currentRoom: Room | null;
+  createRoom: (quiz: Quiz) => string;
+  addStudent: (studentName: string) => void;
+  removeStudent: (studentId: string) => void;
+  startQuiz: () => void;
+  endQuiz: () => void;
+  getRoomByCode: (code: string) => Room | null;
+  closeRoom: () => void;
+};
+
+export type Professor = {
+  id: string;
+  name: string;
+  email: string;
+  type: 'professor';
+};
+
+export type QuestionData = {
+  enunciado: string;
+  alternativas: { texto: string }[];
+};
+
+export type Result = {
+  id: string;
+  name: string;
+  score: number;
+  totalQuestions: number;
+};
+
+
+export type ConfirmModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  title: string;
+  description: string;
+  confirmText?: string;
+  cancelText?: string;
+  variant?: 'danger' | 'success';
+};
+
+export type UserTypeCardProps = {
+  type: 'student' | 'teacher';
+  title: string;
+  iconSrc: string;
+  iconAlt: string;
+  onClick?: () => void;
+};


### PR DESCRIPTION
O que foi feito

- Substituição de todas as interfaces por type
- Centralização das definições de tipos em um único local (/types)
- Organização dos tipos para melhorar reutilização e manutenção

Revisão :  @KaioGabriel-the 